### PR TITLE
Update fs-ext version to avoid node v4 errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "ttembed-js": "bin/ttembed-js"
   },
   "dependencies": {
-    "fs-ext": "0.4.5",
+    "fs-ext": "0.5.0",
     "posix-getopt": "1.0.0"
   }
 }


### PR DESCRIPTION
There are compilation errors on my node 4.4 during installing the package. This PR fixes this issue.
