### PR TITLE
Update fs-ext version to avoid node v4 errors #4

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "ttembed-js": "bin/ttembed-js"
   },
   "dependencies": {
-    "fs-ext": "0.4.5",
+    "fs-ext": "0.5.0",
     "posix-getopt": "1.0.0"
   }
 }


### PR DESCRIPTION
https://github.com/thegregorator/ttembed-js/pull/4/commits/39ffdfd51ec426a69b1cd6e520d919ab9f344376
